### PR TITLE
Reformat back to original formatting for easier comparison

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,15 +1,11 @@
 HIRE ME/PAY ME License (Modified 2 Clause BSD License)
 Copyright 2011, Samveen S. Gulati. All rights reserved.
 
-Redistribution and use in source and binary forms, with or without modification,
-are permitted provided that the following conditions are met:
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
 
-   1. Redistributions of source code must retain the above copyright notice,
-      this list of conditions and the following disclaimer.
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
 
-   2. Redistributions in binary form must reproduce the above copyright notice,
-      this list of conditions and the following disclaimer in the documentation
-      and/or other materials provided with the distribution.
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
 
    3. The user must provide high-paying employment to the copyright holder,
       unless the user wishes otherwise.
@@ -17,17 +13,13 @@ are permitted provided that the following conditions are met:
    4. The user must donate big money to the copyright holder, unless the user
       wishes otherwise.
 
-THIS SOFTWARE IS PROVIDED BY SAMVEEN S. GULATI ''AS IS'' AND ANY EXPRESS OR
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
 IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
 MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
-SHALL SAMVEEN S GULATI OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
 INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
 LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
 PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
 LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
 OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
 ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-The views and conclusions contained in the software and documentation are those of the
-authors and should not be interpreted as representing official policies, either expressed
-or implied, of Samveen S. Gulati.


### PR DESCRIPTION
Fix the license text to match the source formatting as listed in https://opensource.org/license/bsd-2-clause, and remove final views and conclusions section, for easier comparison.

Needed for https://github.com/pidcodes/pidcodes.github.com/pull/963